### PR TITLE
attachment-section example: allow http/s or no protocol

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -263,7 +263,7 @@ TrelloPowerUp.initialize({
 
     // we will just claim urls for Yellowstone
     var claimed = options.entries.filter(function(attachment){
-      return attachment.url.indexOf('http://www.nps.gov/yell/') === 0;
+      return attachment.url.indexOf('www.nps.gov/yell/') > -1;
     });
 
     // you can have more than one attachment section on a card


### PR DESCRIPTION
After remixing this project I tried out the attachment-sections part with links obtained from the nps.gov/yell website but all pages are redirected to https, so the attachment section didn't show.

This change allows for http/s or no protocol.